### PR TITLE
Stripping Inline Styles and Overriding Previous Declarations

### DIFF
--- a/jquery.baseline.js
+++ b/jquery.baseline.js
@@ -24,7 +24,7 @@
 				tall = $this.height(); // Grab the height
 				newHeight = Math.floor(tall / target) * target; // Make up a new height based on the baseline
 				$this.css('maxHeight', newHeight); // Set it!
-			}
+			};
 
 			setbase(target); // Call on load
 
@@ -34,6 +34,6 @@
 
 		});
 
-	}
+	};
 
 }) ( jQuery );


### PR DESCRIPTION
I think I nutted out issue #1.

When setting the new `max-height`, the new value will no longer strip existing inline styles and will override any max-height declaration in `<style>` tags or linked stylesheets.

[Link to demo](http://jsbin.com/ebiqof/3/edit#javascript,html,live)
