### PR TITLE
baseline.target needs to be set before before baseline.setbase() is called.

### DIFF
--- a/baseline.js
+++ b/baseline.js
@@ -10,8 +10,8 @@
 
 /*
 	//call like so
-	baseline.init('img', '24');
-	baseline.init('.post img', '48');
+	baseline.init('img',  24);
+	baseline.init('.post img',  48);
 	baseline.init('#content img', {480: 30, 640: 35}); // an object of breakpoints, ie. 480px or above, baseline is 30px.
 */
 


### PR DESCRIPTION
Testing the vanilla script I noticed that my images were not resizing. I discovered that `baseline.newHeight` was never being set because `baseline.target` was undefined. The best solution I found was to call `baseline.tellmetarget()` before `baseline.setbase()`.
