### PR TITLE
Attach resize event with addEventListener

### DIFF
--- a/baseline.js
+++ b/baseline.js
@@ -27,10 +27,12 @@ var baseline = function(){
 			this.setbase(this.images);
 			this.tellmetarget(target);
 			var me = this;
-			window.onresize = function() {
+			var onresize = function() {
 				me.tellmetarget(target);
 				me.setbase(me.images);
 			};
+			if(window.addEventListener) window.addEventListener('resize', onresize, false);
+			else if(window.attachEvent) window.attachEvent('onresize', onresize);
 		},
 
 		tellmetarget: function(target){


### PR DESCRIPTION
Assigning listeners to `window.onresize` overwrites any previously attached listeners. 
Using addEventListener to attach events to avoid overwriting.

Also has a fix for variable x added to global scope by declaring x.
