### PR TITLE
Use modulo division to calculate adjustment

### DIFF
--- a/baseline.js
+++ b/baseline.js
@@ -58,7 +58,7 @@
        * adjacent element down far enough to get back onto the baseline.
        */
 
-      element.style.marginBottom = Math.ceil(height / _base) * _base - height + _base + 'px';
+      element.style.marginBottom = _base - (height % _base) + 'px';
     }
 
     /**


### PR DESCRIPTION
This is a textbook case for modulo and has the additional benefit of the smallest margin necessary being set (between `0..(baseline - 1)`) while continuing to work for images with a height < baseline.
